### PR TITLE
Fixed compilation issues on 5.9+ kernel versions

### DIFF
--- a/linux/drivers/dahdi/dahdi-base.c
+++ b/linux/drivers/dahdi/dahdi-base.c
@@ -53,6 +53,11 @@
 #include <linux/ktime.h>
 #include <linux/slab.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+# define HAVE_UNLOCKED_IOCTL 1
+# define HAVE_COMPAT_IOCTL 1
+#endif
+
 #if defined(HAVE_UNLOCKED_IOCTL) && defined(CONFIG_BKL)
 #include <linux/smp_lock.h>
 #endif

--- a/linux/drivers/dahdi/dahdi_transcode.c
+++ b/linux/drivers/dahdi/dahdi_transcode.c
@@ -38,6 +38,11 @@
 
 #include <dahdi/kernel.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+# define HAVE_UNLOCKED_IOCTL 1
+# define HAVE_COMPAT_IOCTL 1
+#endif
+
 static int debug;
 /* The registration list contains transcoders in the order in which they were
  * registered. */


### PR DESCRIPTION
HAVE_UNLOCKED_IOCTL and HAVE_COMPAT_IOCTL were removed in Linux kernel version 5.9. This change checks the kernel version and redefines those preprocessor variables to allow the proper ioctl to be used.

See https://patchwork.kernel.org/patch/11696859/

The issue was discovered on a Pi running Raspberry Pi OS with kernel 5.10.17-v7+. 

73 de KE5GDB
